### PR TITLE
fix: Use intended link destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 <p align="left"> <a href="https://github.com/ryo-ma/github-profile-trophy"><img src="https://github-profile-trophy.vercel.app/?username=aaronkellyuk" alt="aaronkellyuk" /></a> </p>
 
-- 🔭 I’m currently working on [LUCompSoc](compsoc.io)
+- 🔭 I’m currently working on [LUCompSoc](https://compsoc.io)
 
-- 👨‍💻 All of my projects are available at [github.com/aaronkellyuk](github.com/aaronkellyuk)
+- 👨‍💻 All of my projects are available at [github.com/aaronkellyuk](https://github.com/aaronkellyuk)
 
 <h3 align="left">Connect with me:</h3>
 <p align="left">


### PR DESCRIPTION
The link format previously used did not lead to the relevant sites as they were specified as relative paths. Prepending `https://` to each of these fixes that issue.